### PR TITLE
Fixed null tag.related_list

### DIFF
--- a/web/api/serializer/heritage.py
+++ b/web/api/serializer/heritage.py
@@ -34,11 +34,11 @@ class HeritageSerializer(serializers.ModelSerializer):
             tag, created = Tag.objects.get_or_create(name=tag_data['name'])
             if created:
                 concepts_list = helper.get_concepts_from_item(tag.name)
-                jdata = {}
-                for item in concepts_list:
-                    jdata[item[0]] = item[1]
-
-                tag.setlist(jdata)
+                taglist = ""
+                for word in [x[0] for x in concepts_list]:
+                    taglist += word + " "
+                tag.related_list = taglist
+                tag.save()
 
             heritage.tags.add(tag)
 
@@ -67,6 +67,13 @@ class HeritageSerializer(serializers.ModelSerializer):
 
         for tag_data in new_tags_data:
             tag, created = Tag.objects.get_or_create(name=tag_data['name'])
+            if created:
+                concepts_list = helper.get_concepts_from_item(tag.name)
+                taglist = ""
+                for word in [x[0] for x in concepts_list]:
+                    taglist += word + " "
+                tag.related_list = taglist
+                tag.save()
             instance.tags.add(tag)
 
 

--- a/web/api/serializer/tag.py
+++ b/web/api/serializer/tag.py
@@ -5,4 +5,4 @@ from rest_framework import serializers
 class TagSerializer(serializers.ModelSerializer):
     class Meta:
         model = Tag
-        fields = "__all__"
+        fields = ("id", "name")


### PR DESCRIPTION
Tag.related_list was remaining null when creating or updating heritages. Now they're generated.

Also, removed Tag.related_list from the Tag serializer as it is only used in backend.