### PR TITLE
Timezone update

### DIFF
--- a/web/api/controller/heritage.py
+++ b/web/api/controller/heritage.py
@@ -159,6 +159,7 @@ def get_top_heritages(request):
 @permission_classes((AllowAny, ))
 def get_trending_heritages(request):
     try:
+        now = datetime.datetime.utcnow()+datetime.timedelta(hours=3)
         context = {}
         if request.user.username:
             profile_id = Profile.objects.filter(username=request.user.username).first().pk
@@ -167,7 +168,7 @@ def get_trending_heritages(request):
         heritages = Heritage.objects.all()
         myList = []
         for item in heritages:
-            votes = item.votes.filter(update_date__gte=datetime.datetime.utcnow()-datetime.timedelta(days=7))
+            votes = item.votes.filter(update_date__gte=now-datetime.timedelta(days=7))
             score = votes.filter(value=True).count() - votes.filter(value=False).count()
             myList.append((item, score ))
 

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -129,7 +129,7 @@ LANGUAGE_CODE = 'en-us'
 
 DEFAULT_CHARSET = 'utf-8'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Europe/Istanbul'
 
 USE_I18N = True
 


### PR DESCRIPTION
Django now uses the timezone of Istanbul.

When making a GET /items/trending/ request, we are getting a warning about our datetime field being naive, but as far as I can see from my tests, it is working as intended.

If you want to test /items/trending/ yourselves, keep in mind that it is filtering the votes cast this week, not the heritages created.