### PR TITLE
Set a lower bound of 3 for search

### DIFF
--- a/web/api/controller/search.py
+++ b/web/api/controller/search.py
@@ -54,6 +54,11 @@ def search(request):
 
     sorted_tuple = sorted(ll.items(), key=operator.itemgetter(1), reverse=True)
     print sorted_tuple
+    for index in range(len(sorted_tuple)):
+        if sorted_tuple[index][1] < 3:
+            sorted_tuple = sorted_tuple[:index]
+            break
+
     response = []
 
     for item in sorted_tuple:


### PR DESCRIPTION
Only item with scores greater than or equal to 3 will show up making doing a search.

Does not change the way the search mechanism should be used by frontend or android.